### PR TITLE
Add Schwab API demo

### DIFF
--- a/schwab_app/README.md
+++ b/schwab_app/README.md
@@ -1,0 +1,28 @@
+# Schwab API Demo
+
+This example demonstrates how to interact with the Charles Schwab Developer API
+for retrieving account data, researching stocks, and placing trades. It uses the
+`requests` library and supports the following API endpoints:
+
+- **Accounts** – list accounts and positions.
+- **Market Data** – quotes and historical prices.
+- **Instruments** – search for stock symbols.
+- **News** – company news.
+- **Trading** – place and cancel orders.
+
+## Usage
+
+1. Obtain an API key and OAuth access token from the Schwab Developer Portal.
+2. Install the required Python packages:
+
+   ```bash
+   pip install requests
+   ```
+
+3. Run the demo app:
+
+   ```bash
+   python -m schwab_app.app <API_KEY> <ACCESS_TOKEN> <SYMBOL> <ACCOUNT_ID>
+   ```
+
+The script will call several Schwab APIs and print the JSON responses.

--- a/schwab_app/app.py
+++ b/schwab_app/app.py
@@ -1,0 +1,44 @@
+"""Command-line application demonstrating Schwab API usage."""
+
+import argparse
+import json
+from schwab_app.schwab_client import SchwabClient
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Schwab API demo")
+    parser.add_argument("api_key", help="Schwab API key")
+    parser.add_argument("access_token", help="OAuth access token")
+    parser.add_argument("symbol", help="Symbol to query")
+    parser.add_argument("account_id", help="Account ID")
+    args = parser.parse_args()
+
+    client = SchwabClient(api_key=args.api_key, access_token=args.access_token)
+
+    print("Fetching account information...")
+    accounts = client.get_accounts()
+    print(json.dumps(accounts, indent=2))
+
+    print("\nFetching positions...")
+    positions = client.get_positions(args.account_id)
+    print(json.dumps(positions, indent=2))
+
+    print("\nFetching quote...")
+    quote = client.get_quote(args.symbol)
+    print(json.dumps(quote, indent=2))
+
+    print("\nSearching instruments...")
+    search = client.search_instruments(args.symbol)
+    print(json.dumps(search, indent=2))
+
+    print("\nFetching news...")
+    news = client.get_news(args.symbol)
+    print(json.dumps(news, indent=2))
+
+    print("\nFetching historical prices...")
+    hist = client.get_historical_prices(args.symbol)
+    print(json.dumps(hist, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/schwab_app/schwab_client.py
+++ b/schwab_app/schwab_client.py
@@ -1,0 +1,78 @@
+import os
+from typing import Dict, Any, Optional
+import requests
+
+class SchwabClient:
+    """Simple client for the Charles Schwab Developer API."""
+
+    def __init__(self, api_key: str, access_token: Optional[str] = None):
+        self.api_key = api_key
+        self.access_token = access_token or os.getenv("SCHWAB_ACCESS_TOKEN")
+        self.base_url = "https://api.schwab.com"
+
+    def _headers(self) -> Dict[str, str]:
+        if not self.access_token:
+            raise ValueError("Access token required")
+        return {
+            "Authorization": f"Bearer {self.access_token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "schwab-api-key": self.api_key,
+        }
+
+    def get_accounts(self) -> Dict[str, Any]:
+        """Retrieve account information."""
+        url = f"{self.base_url}/accounts"
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def get_positions(self, account_id: str) -> Dict[str, Any]:
+        """Retrieve positions for an account."""
+        url = f"{self.base_url}/accounts/{account_id}/positions"
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def get_quote(self, symbol: str) -> Dict[str, Any]:
+        """Get a real-time quote for a symbol."""
+        url = f"{self.base_url}/marketdata/{symbol}/quotes"
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def search_instruments(self, query: str) -> Dict[str, Any]:
+        """Search for instruments by symbol or name."""
+        url = f"{self.base_url}/instruments"
+        params = {"search": query}
+        response = requests.get(url, headers=self._headers(), params=params)
+        response.raise_for_status()
+        return response.json()
+
+    def place_order(self, account_id: str, order_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Place a trade order."""
+        url = f"{self.base_url}/accounts/{account_id}/orders"
+        response = requests.post(url, headers=self._headers(), json=order_data)
+        response.raise_for_status()
+        return response.json()
+
+    def cancel_order(self, account_id: str, order_id: str) -> None:
+        """Cancel an existing order."""
+        url = f"{self.base_url}/accounts/{account_id}/orders/{order_id}"
+        response = requests.delete(url, headers=self._headers())
+        response.raise_for_status()
+
+    def get_news(self, symbol: str) -> Dict[str, Any]:
+        """Retrieve news articles for a given symbol."""
+        url = f"{self.base_url}/marketdata/{symbol}/news"
+        response = requests.get(url, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def get_historical_prices(self, symbol: str, period: str = "1y") -> Dict[str, Any]:
+        """Fetch historical price data."""
+        url = f"{self.base_url}/marketdata/{symbol}/pricehistory"
+        params = {"period": period}
+        response = requests.get(url, headers=self._headers(), params=params)
+        response.raise_for_status()
+        return response.json()


### PR DESCRIPTION
## Summary
- add new Schwab API demo app with client, CLI, and docs

## Testing
- `python -m py_compile schwab_app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6861f2fbe5288320aef326f5691645ee